### PR TITLE
feat: configurable Coraza output

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,13 @@ docker run \
     ghcr.io/jcchavezs/coraza-httpbin:main \
     -directives /path-to-directives-file/directives.conf
 ```
+
+### Logging
+
+By default, coraza-httpbin will log Coraza messages to stdout. You can specify a log file by using the `-log-file` flag:
+
+```shell
+go run github.com/jcchavezs/coraza-httpbin/cmd/coraza-httpbin@latest \
+  -directives ./directives.conf.example \
+  -log-file coraza_log.log
+```

--- a/cmd/coraza-httpbin/main.go
+++ b/cmd/coraza-httpbin/main.go
@@ -19,6 +19,7 @@ import (
 
 var (
 	port           int
+	logFile        string
 	directivesFile string
 )
 
@@ -61,12 +62,23 @@ func createWAF(directivesFile string) (coraza.WAF, error) {
 	return waf, nil
 }
 
+func configureLog() {
+	file, err := os.OpenFile(logFile, os.O_CREATE|os.O_RDWR, os.ModePerm)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	os.Stdout = file
+}
+
 func main() {
 	flag.IntVar(&port, "port", getEnvInt("PORT", 8080), "Port to listen on")
+	flag.StringVar(&logFile, "log-file", getEnvString("LOG_FILE", "/dev/stdout"), "File to log to")
 	flag.StringVar(&directivesFile, "directives", getEnvString("DIRECTIVES_FILE", ""), "Directives file to use")
 
 	// parse flags from command line
 	flag.Parse()
+	configureLog()
 
 	waf, err := createWAF(directivesFile)
 	if err != nil {


### PR DESCRIPTION
A new `-log-file` flag enables configuration of the file where Coraza messages are written to.