### PR TITLE
fix: updates CRS dependency to CRS 4.0.0-rc2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jcchavezs/coraza-httpbin
 go 1.19
 
 require (
-	github.com/corazawaf/coraza-coreruleset v0.0.0-20231030141218-0911b8ad6a6a
+	github.com/corazawaf/coraza-coreruleset v0.0.0-20231103220038-fd5c847140a6
 	github.com/corazawaf/coraza/v3 v3.0.4
 	github.com/jcchavezs/mergefs v0.0.0-20230503083351-07f27d256761
 	github.com/magefile/mage v1.15.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/corazawaf/coraza-coreruleset v0.0.0-20231030141218-0911b8ad6a6a h1:OIsUTxTp2axNLRvqYjATq8uCn36WjJYfzRUOcXMVIjg=
-github.com/corazawaf/coraza-coreruleset v0.0.0-20231030141218-0911b8ad6a6a/go.mod h1:7rsocqNDkTCira5T0M7buoKR2ehh7YZiPkzxRuAgvVU=
+github.com/corazawaf/coraza-coreruleset v0.0.0-20231103220038-fd5c847140a6 h1:MjSFYff3j1L4zo3MNuqnQ19Jp5ps/sibntdtS/Kq/yk=
+github.com/corazawaf/coraza-coreruleset v0.0.0-20231103220038-fd5c847140a6/go.mod h1:7rsocqNDkTCira5T0M7buoKR2ehh7YZiPkzxRuAgvVU=
 github.com/corazawaf/coraza/v3 v3.0.4 h1:Llemgoh0hp2NggCwcWN8lNiV4Pfe+AWzf1oEcasT234=
 github.com/corazawaf/coraza/v3 v3.0.4/go.mod h1:3fTYjY5BZv3nezLpH6NAap0gr3jZfbQWUAu2GF17ET4=
 github.com/corazawaf/libinjection-go v0.1.2 h1:oeiV9pc5rvJ+2oqOqXEAMJousPpGiup6f7Y3nZj5GoM=


### PR DESCRIPTION
follows https://github.com/corazawaf/coraza-coreruleset/pull/9. The PR removes leftover files, there should not be a change in terms of matched rules